### PR TITLE
Bump to v0.4.0 and add UPGRADING docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### 0.3.4 (Next)
+### 0.4.0 (next)
 
 * Your contribution here.
+
 * [#9](https://github.com/dblock/iex-ruby-client/pull/9): Added `IEX::Errors::ClientError` - [@rodolfobandeira](https://github.com/rodolfobandeira).
 * [#10](https://github.com/dblock/iex-ruby-client/pull/10): Added `IEX::Resources::Logo#get` - [@rodolfobandeira](https://github.com/rodolfobandeira).
 

--- a/README.md
+++ b/README.md
@@ -162,10 +162,6 @@ If a symbol cannot be found an [IEX::Errors::SymbolNotFound](lib/iex/errors/symb
 
 All errors that return HTTP codes 400-600 result in a [IEX::Errors::ClientError](lib/iex/errors/client_error.rb) exception.
 
-```ruby
-IEX::Resources::Chart.get('MSFT', '1d', chart_interval: 10, invalid_option: 'foo')
-```
-
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,26 @@
+Upgrading iex-ruby-client
+===========================
+
+### Upgrading to >= 0.4.0
+
+#### All errors that return HTTP codes 400-600 result in a IEX::Errors::ClientError exception
+
+On previous versions, calling `IEX::Resources::Chart.get` with an invalid option results on a
+`Faraday::ClientError`. On versions >= 0.4.0, it will return an `IEX::Errors::ClientError`.
+
+Before:
+
+```ruby
+IEX::Resources::Chart.get('MSFT', '1d', chart_interval: 10, invalid_option: 'foo')
+> Faraday::ClientError: the server responded with status 400
+```
+
+After: 
+
+```ruby
+IEX::Resources::Chart.get('MSFT', '1d', chart_interval: 10, invalid_option: 'foo')
+> IEX::Errors::ClientError: "invalidOption" is not allowed
+```
+
+See [#9](https://github.com/dblock/iex-ruby-client/pull/9) for more information.
+

--- a/lib/iex/version.rb
+++ b/lib/iex/version.rb
@@ -1,3 +1,3 @@
 module IEX
-  VERSION = '0.3.4'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
close #13 

If I understood well, since this release will be a major upgrade `(v0.4.0)`, the next version will actually be `v0.4.1`. I noticed on the git history that you @dblock and @jromanovs changed the `version` in two commits, only after indeed releasing at rubygems.org. I already changed the version in advance but added tomorrow's release date. 

Please let me know if that makes sense.