### PR TITLE
Remove default range and use iextrading default range 1m instead in `IEX::Api::Dividends`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 0.4.4 (next)
 
+* [#39](https://github.com/dblock/iex-ruby-client/pull/39): Remove default range and use iextrading default range 1m instead in `IEX::Api::Dividends` - [@ildarkayumov](https://github.com/ildarkayumov).
 * [#37](https://github.com/dblock/iex-ruby-client/pull/37): Add `IEX::Resource::Crypto` - [@rodolfobandeira](https://github.com/rodolfobandeira).
 * [#34](https://github.com/dblock/iex-ruby-client/pull/34): Add `IEX::Resource::LargestTrades` - [@gil27](https://github.com/gil27).
 * [#32](https://github.com/dblock/iex-ruby-client/pull/32): Add `IEX::Resource::Sectors` - [@gil27](https://github.com/gil27).

--- a/lib/iex/api/dividends.rb
+++ b/lib/iex/api/dividends.rb
@@ -9,8 +9,7 @@ module IEX
         IEX::Api.default_connection [
           symbol,
           'dividends',
-          range ? '6m' : nil,
-          range
+          range ? range : '6m'
         ].compact.join('/')
       end
     end

--- a/lib/iex/api/dividends.rb
+++ b/lib/iex/api/dividends.rb
@@ -9,7 +9,7 @@ module IEX
         IEX::Api.default_connection [
           symbol,
           'dividends',
-          range ? range : '6m'
+          range
         ].compact.join('/')
       end
     end

--- a/spec/fixtures/iex/dividends/invalid.yml
+++ b/spec/fixtures/iex/dividends/invalid.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.iextrading.com/1.0/stock/INVALID/dividends/6m/INVALID
+    uri: https://api.iextrading.com/1.0/stock/INVALID/dividends/INVALID
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.2
+      - Faraday v0.15.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 10 Aug 2018 19:58:42 GMT
+      - Thu, 08 Nov 2018 15:42:18 GMT
       Content-Type:
       - text/html; charset=utf-8
       Transfer-Encoding:
@@ -29,8 +29,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=b745053a8bbf4a93bb35eb797014e8bd; Domain=.iextrading.com; Path=/; Expires=Sat,
-        11 Aug 2018 07:58:42 GMT; Secure
+      - ctoken=8253e41ad52741a9b52de8e3b3741da1; Domain=.iextrading.com; Path=/; Expires=Fri,
+        09 Nov 2018 03:42:18 GMT; Secure
       Content-Security-Policy:
       - default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self'
         'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com
@@ -61,5 +61,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: Unknown symbol
     http_version: 
-  recorded_at: Fri, 10 Aug 2018 19:58:42 GMT
+  recorded_at: Thu, 08 Nov 2018 15:42:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/iex/dividends/msft.yml
+++ b/spec/fixtures/iex/dividends/msft.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends/6m/6m
+    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends/6m
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.2
+      - Faraday v0.15.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,16 +21,16 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 10 Aug 2018 19:58:42 GMT
+      - Thu, 08 Nov 2018 15:42:15 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '371'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=4cd7bd7bcc2c4ee4b5db344ca760c90c; Domain=.iextrading.com; Path=/; Expires=Sat,
-        11 Aug 2018 07:58:42 GMT; Secure
+      - ctoken=a960d585020d48c8a0a44ab8a7d3d5c4; Domain=.iextrading.com; Path=/; Expires=Fri,
+        09 Nov 2018 03:42:15 GMT; Secure
       Content-Security-Policy:
       - default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self'
         'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com
@@ -60,10 +60,10 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Origin, X-Requested-With, Content-Type, Accept
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: '[{"exDate":"2018-02-14","paymentDate":"2018-03-08","recordDate":"2018-02-15","declaredDate":"2017-11-29","amount":0.42,"flag":"","type":"Dividend
         income","qualified":"Q","indicated":""},{"exDate":"2017-11-15","paymentDate":"2017-12-14","recordDate":"2017-11-16","declaredDate":"2017-09-19","amount":0.42,"flag":"","type":"Dividend
         income","qualified":"Q","indicated":""}]'
     http_version: 
-  recorded_at: Fri, 10 Aug 2018 19:58:42 GMT
+  recorded_at: Thu, 08 Nov 2018 15:42:15 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/iex/dividends/msft_1y.yml
+++ b/spec/fixtures/iex/dividends/msft_1y.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends/6m/1y
+    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends/1y
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.2
+      - Faraday v0.15.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,16 +21,16 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 10 Aug 2018 19:58:42 GMT
+      - Thu, 08 Nov 2018 15:42:17 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '371'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=36ba9e13ade0470e938240d302a243c1; Domain=.iextrading.com; Path=/; Expires=Sat,
-        11 Aug 2018 07:58:42 GMT; Secure
+      - ctoken=5f937f0a76f04d66b493857b554a86c9; Domain=.iextrading.com; Path=/; Expires=Fri,
+        09 Nov 2018 03:42:17 GMT; Secure
       Content-Security-Policy:
       - default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self'
         'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com
@@ -60,10 +60,12 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Origin, X-Requested-With, Content-Type, Accept
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: '[{"exDate":"2018-02-14","paymentDate":"2018-03-08","recordDate":"2018-02-15","declaredDate":"2017-11-29","amount":0.42,"flag":"","type":"Dividend
         income","qualified":"Q","indicated":""},{"exDate":"2017-11-15","paymentDate":"2017-12-14","recordDate":"2017-11-16","declaredDate":"2017-09-19","amount":0.42,"flag":"","type":"Dividend
+        income","qualified":"Q","indicated":""},{"exDate":"2017-08-15","paymentDate":"2017-09-14","recordDate":"2017-08-17","declaredDate":"2017-06-13","amount":0.39,"flag":"","type":"Dividend
+        income","qualified":"Q","indicated":""},{"exDate":"2017-05-16","paymentDate":"2017-06-08","recordDate":"2017-05-18","declaredDate":"2017-03-14","amount":0.39,"flag":"","type":"Dividend
         income","qualified":"Q","indicated":""}]'
     http_version: 
-  recorded_at: Fri, 10 Aug 2018 19:58:42 GMT
+  recorded_at: Thu, 08 Nov 2018 15:42:17 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/iex/dividends/msft_default_range.yml
+++ b/spec/fixtures/iex/dividends/msft_default_range.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends
+    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends/6m
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.2
+      - Faraday v0.15.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,16 +21,16 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 11 Aug 2018 13:16:51 GMT
+      - Thu, 08 Nov 2018 15:42:16 GMT
       Content-Type:
       - application/json; charset=utf-8
-      Content-Length:
-      - '186'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=ccb88e016a434ff3b028933badc76184; Domain=.iextrading.com; Path=/; Expires=Sun,
-        12 Aug 2018 01:16:51 GMT; Secure
+      - ctoken=9a22a87041a24b10acc0234239d71f93; Domain=.iextrading.com; Path=/; Expires=Fri,
+        09 Nov 2018 03:42:16 GMT; Secure
       Content-Security-Policy:
       - default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self'
         'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com
@@ -60,9 +60,10 @@ http_interactions:
       Access-Control-Allow-Headers:
       - Origin, X-Requested-With, Content-Type, Accept
     body:
-      encoding: UTF-8
+      encoding: ASCII-8BIT
       string: '[{"exDate":"2018-02-14","paymentDate":"2018-03-08","recordDate":"2018-02-15","declaredDate":"2017-11-29","amount":0.42,"flag":"","type":"Dividend
+        income","qualified":"Q","indicated":""},{"exDate":"2017-11-15","paymentDate":"2017-12-14","recordDate":"2017-11-16","declaredDate":"2017-09-19","amount":0.42,"flag":"","type":"Dividend
         income","qualified":"Q","indicated":""}]'
     http_version: 
-  recorded_at: Sat, 11 Aug 2018 13:16:51 GMT
+  recorded_at: Thu, 08 Nov 2018 15:42:16 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/iex/dividends/msft_default_range.yml
+++ b/spec/fixtures/iex/dividends/msft_default_range.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends/6m
+    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends
     body:
       encoding: US-ASCII
       string: ''
@@ -21,7 +21,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Thu, 08 Nov 2018 15:42:16 GMT
+      - Thu, 15 Nov 2018 07:32:08 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -29,8 +29,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=9a22a87041a24b10acc0234239d71f93; Domain=.iextrading.com; Path=/; Expires=Fri,
-        09 Nov 2018 03:42:16 GMT; Secure
+      - ctoken=3593cacf28944137a79f569b94101526; Domain=.iextrading.com; Path=/; Expires=Thu,
+        15 Nov 2018 19:32:08 GMT; Secure
       Content-Security-Policy:
       - default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self'
         'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com
@@ -62,8 +62,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '[{"exDate":"2018-02-14","paymentDate":"2018-03-08","recordDate":"2018-02-15","declaredDate":"2017-11-29","amount":0.42,"flag":"","type":"Dividend
-        income","qualified":"Q","indicated":""},{"exDate":"2017-11-15","paymentDate":"2017-12-14","recordDate":"2017-11-16","declaredDate":"2017-09-19","amount":0.42,"flag":"","type":"Dividend
         income","qualified":"Q","indicated":""}]'
     http_version: 
-  recorded_at: Thu, 08 Nov 2018 15:42:16 GMT
+  recorded_at: Thu, 15 Nov 2018 07:32:08 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/iex/dividends/msft_invalid_range.yml
+++ b/spec/fixtures/iex/dividends/msft_invalid_range.yml
@@ -2,13 +2,13 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends/6m/INVALID
+    uri: https://api.iextrading.com/1.0/stock/MSFT/dividends/INVALID
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - Faraday v0.15.2
+      - Faraday v0.15.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -21,16 +21,16 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 11 Aug 2018 13:18:55 GMT
+      - Thu, 08 Nov 2018 15:42:17 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '371'
+      - '2'
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=810c099ba2f8423e9f5adb38c85efd59; Domain=.iextrading.com; Path=/; Expires=Sun,
-        12 Aug 2018 01:18:55 GMT; Secure
+      - ctoken=4c5cef42b56445a0b723b05c4fee4cd3; Domain=.iextrading.com; Path=/; Expires=Fri,
+        09 Nov 2018 03:42:17 GMT; Secure
       Content-Security-Policy:
       - default-src 'self'; child-src 'none'; object-src 'none'; style-src 'self'
         'unsafe-inline'; font-src data:; frame-src 'self'; connect-src 'self' https://auth.iextrading.com
@@ -61,9 +61,7 @@ http_interactions:
       - Origin, X-Requested-With, Content-Type, Accept
     body:
       encoding: UTF-8
-      string: '[{"exDate":"2018-02-14","paymentDate":"2018-03-08","recordDate":"2018-02-15","declaredDate":"2017-11-29","amount":0.42,"flag":"","type":"Dividend
-        income","qualified":"Q","indicated":""},{"exDate":"2017-11-15","paymentDate":"2017-12-14","recordDate":"2017-11-16","declaredDate":"2017-09-19","amount":0.42,"flag":"","type":"Dividend
-        income","qualified":"Q","indicated":""}]'
+      string: "[]"
     http_version: 
-  recorded_at: Sat, 11 Aug 2018 13:18:55 GMT
+  recorded_at: Thu, 08 Nov 2018 15:42:17 GMT
 recorded_with: VCR 4.0.0

--- a/spec/iex/resources/dividends_spec.rb
+++ b/spec/iex/resources/dividends_spec.rb
@@ -23,7 +23,7 @@ describe IEX::Resources::Dividends do
         IEX::Resources::Dividends.get('MSFT')
       end
       it 'retrieves dividends when no range is passed' do
-        expect(subject.size).to eq 2
+        expect(subject.size).to eq 1
       end
     end
     context 'invalid range', vcr: { cassette_name: 'dividends/msft_invalid_range' } do

--- a/spec/iex/resources/dividends_spec.rb
+++ b/spec/iex/resources/dividends_spec.rb
@@ -23,7 +23,7 @@ describe IEX::Resources::Dividends do
         IEX::Resources::Dividends.get('MSFT')
       end
       it 'retrieves dividends when no range is passed' do
-        expect(subject.size).to eq 1
+        expect(subject.size).to eq 2
       end
     end
     context 'invalid range', vcr: { cassette_name: 'dividends/msft_invalid_range' } do
@@ -32,8 +32,7 @@ describe IEX::Resources::Dividends do
       end
       let(:dividends) { subject.first }
       it 'retrieves dividends when invalid range is passed' do
-        expect(subject.size).to eq 2 # Falls into default 1 year
-        expect(dividends.type).to eq 'Dividend income'
+        expect(subject.size).to eq 0
       end
     end
     context 'with range', vcr: { cassette_name: 'dividends/msft_1y' } do
@@ -41,7 +40,7 @@ describe IEX::Resources::Dividends do
         IEX::Resources::Dividends.get('MSFT', '1y')
       end
       it 'retrieves dividends with range of 1 year' do
-        expect(subject.size).to eq 2
+        expect(subject.size).to eq 4
       end
     end
   end


### PR DESCRIPTION
It looks like there is a typo when using range option.

for example 

```ruby
  IEX::Resources::Dividends.get('AAPL', '5y')
``` 

generates

```ruby
  "AAPL/dividends/6m/5y"
```

instead of

```ruby
  "AAPL/dividends/5y"
```

as described in docs - https://iextrading.com/developer/docs/#dividends
