### PR TITLE
Add missing properties for key stats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.0.1 (Next)
 
 * Your contribution here.
+* [#50](https://github.com/dblock/iex-ruby-client/pull/50): Add missing properties for key stats API - [@bingxie](https://github.com/bingxie).
 
 ### 1.0.0 (2019/04/23)
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ client = IEX::Api::Client.new(publishable_token: 'token')
 Fetches a single number, being the IEX real time price, the 15 minute delayed market price, or the previous close price.
 
 ```ruby
-client.get('MSFT') # 93.78
+client.price('MSFT') # 93.78
 ```
 
 See [#price](https://iexcloud.io/docs/api/#price) for detailed documentation.
@@ -193,35 +193,48 @@ Fetches company's key stats for a symbol.
 ```ruby
 key_stats = client.key_stats('MSFT')
 
-key_stats.market_cap # 825814890000
-key_stats.market_cap_dollars # '$825,814,890,000'
-key_stats.week_52_high # 111.15
-key_stats.week_52_high_dollar # '$111.15'
-key_stats.week_52_low # 71.28
-key_stats.week_52_low_dollar # '$71.28'
-key_stats.week_52_change_dollar # '$51.77'
-key_stats.dividend_yield # 1.5617738
-key_stats.ex_dividend_date # '2018-08-15 00:00:00.0'
-key_stats.shares_outstanding # 7677000000
-key_stats.float # 7217387757
-key_stats.ttm_eps # 3.51
-key_stats.day_200_moving_avg # 91.99065
-key_stats.day_50_moving_avg # 102.2528
-key_stats.year_5_change_percent # 2.85141424991049
-key_stats.year_5_change_percent_s # '+285.14%'
-key_stats.year_2_change_percent # 0.9732002824884664
-key_stats.year_2_change_percent_s # '+97.32%'
-key_stats.year_1_change_percent # 0.5200287133805482
-key_stats.year_1_change_percent_s # '+52.00%'
-key_stats.ytd_change_percent # 0.2628699562098638
-key_stats.month_6_change_percent # 0.23345097958275707
-key_stats.month_6_change_percent_s # '+23.35%'
-key_stats.month_3_change_percent # 0.14846686026648437
-key_stats.month_3_change_percent_s # '+14.85%'
-key_stats.month_1_change_percent # 0.08601716304896513
-key_stats.month_1_change_percent_s # '+8.60%'
-key_stats.day_5_change_percent # -0.0010215453194652084
-key_stats.day_5_change_percent_s # '-0.10%'
+key_stats.week_52_change_dollar # "$0.37"
+key_stats.week_52_high # 136.04
+key_stats.week_52_high_dollar # "$136.04"
+key_stats.week_52_low # 95.92,
+key_stats.week_52_low_dollar # "$95.92"
+key_stats.market_cap # 990869169557
+key_stats.market_cap_dollars # "$990,869,169,557"
+key_stats.employees # 133074
+key_stats.day_200_moving_avg # 112.43
+key_stats.day_50_moving_avg # 121
+key_stats.float # 7694414092
+key_stats.avg_10_volume # 25160156.2
+key_stats.avg_30_volume # 23123700.13
+key_stats.ttm_eps # 4.66
+key_stats.ttm_dividend_rate # 1.8
+key_stats.company_name # "Microsoft Corp."
+key_stats.shares_outstanding # 7849945172
+key_stats.max_change_percent # 4.355607
+key_stats.year_5_change_percent # 2.32987
+key_stats.year_5_change_percent_s # "+232.99%"
+key_stats.year_2_change_percent # 0.84983
+key_stats.year_2_change_percent_s # "+84.98%"
+key_stats.year_1_change_percent # 0.383503
+key_stats.year_1_change_percent_s # "+38.35%"
+key_stats.ytd_change_percent # 0.270151
+key_stats.ytd_change_percent_s # "+27.02%"
+key_stats.month_6_change_percent # 0.208977
+key_stats.month_6_change_percent_s # "+20.90%"
+key_stats.month_3_change_percent # 0.212188
+key_stats.month_3_change_percent_s # "+21.22%"
+key_stats.month_1_change_percent # 0.076335
+key_stats.month_1_change_percent_s # "+7.63%"
+key_stats.day_30_change_percent # 0.089589
+key_stats.day_30_change_percent_s # "+8.96%"
+key_stats.day_5_change_percent # -0.010013
+key_stats.day_5_change_percent_s # "-1.00%"
+key_stats.next_dividend_date # "2019-05-21"
+key_stats.dividend_yield # 0.014087248841960684
+key_stats.next_earnings_date # "2019-07-29"
+key_stats.ex_dividend_date # "2019-05-24"
+key_stats.pe_ratio # 29.47
+key_stats.beta # 1.4135449089973444
 ```
 
 See [#key-stats](https://iexcloud.io/docs/api/#key-stats) for detailed documentation or [key_stats.rb](lib/iex/resources/key_stats.rb) for returned fields.

--- a/lib/iex/resources/key_stats.rb
+++ b/lib/iex/resources/key_stats.rb
@@ -24,6 +24,7 @@ module IEX
       property 'year_1_change_percent', from: 'year1ChangePercent'
       property 'year_1_change_percent_s', from: 'year1ChangePercent', with: ->(v) { Resource.float_to_percentage(v) }
       property 'ytd_change_percent', from: 'ytdChangePercent'
+      property 'ytd_change_percent_s', from: 'ytdChangePercent', with: ->(v) { Resource.float_to_percentage(v) }
       property 'month_6_change_percent', from: 'month6ChangePercent'
       property 'month_6_change_percent_s', from: 'month6ChangePercent', with: ->(v) { Resource.float_to_percentage(v) }
       property 'month_3_change_percent', from: 'month3ChangePercent'
@@ -32,6 +33,17 @@ module IEX
       property 'month_1_change_percent_s', from: 'month1ChangePercent', with: ->(v) { Resource.float_to_percentage(v) }
       property 'day_5_change_percent', from: 'day5ChangePercent'
       property 'day_5_change_percent_s', from: 'day5ChangePercent', with: ->(v) { Resource.float_to_percentage(v) }
+      property 'employees'
+      property 'avg_10_volume', from: 'avg10Volume'
+      property 'avg_30_volume', from: 'avg30Volume'
+      property 'ttm_dividend_rate', from: 'ttmDividendRate'
+      property 'max_change_percent', from: 'maxChangePercent'
+      property 'day_30_change_percent', from: 'day30ChangePercent'
+      property 'day_30_change_percent_s', from: 'day30ChangePercent', with: ->(v) { Resource.float_to_percentage(v) }
+      property 'next_dividend_date', from: 'nextDividendDate'
+      property 'next_earnings_date', from: 'nextEarningsDate'
+      property 'pe_ratio', from: 'peRatio'
+      property 'beta'
 
       def initialize(data = {})
         super

--- a/spec/fixtures/iex/key_stats/invalid.yml
+++ b/spec/fixtures/iex/key_stats/invalid.yml
@@ -7,12 +7,12 @@ http_interactions:
         encoding: US-ASCII
         string: ""
       headers:
+        Accept:
+          - application/json; charset=utf-8
         User-Agent:
-          - Faraday v0.15.4
+          - IEX Ruby Client/1.0.1
         Accept-Encoding:
           - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-        Accept:
-          - "*/*"
     response:
       status:
         code: 404
@@ -21,7 +21,7 @@ http_interactions:
         Server:
           - nginx
         Date:
-          - Fri, 05 Apr 2019 11:12:07 GMT
+          - Thu, 02 May 2019 12:12:52 GMT
         Content-Type:
           - text/html; charset=utf-8
         Transfer-Encoding:
@@ -29,42 +29,8 @@ http_interactions:
         Connection:
           - keep-alive
         Set-Cookie:
-          - ctoken=7789b1a215e44d0fb0f4f533454ee0e4; Max-Age=43200; Path=/; Expires=Fri,
-            05 Apr 2019 23:12:07 GMT
-        Content-Security-Policy:
-          - "default-src 'self'; child-src 'none'; object-src 'self'; style-src
-            'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self'
-            https://js.intercomcdn.com/fonts/ https://fonts.gstatic.com; frame-src 'self'
-            https://portal.productboard.com/ https://js.stripe.com/; img-src 'self'
-            data: https://*.intercomcdn.com/ https://static.intercomassets.com/ https://www.google-analytics.com
-            https://downloads.intercomcdn.com/; connect-src 'self' https://auth.iexcloud.io
-            https://api.iexcloud.io https://api.iexcloud.io https://cloud.iexapis.com
-            wss://iexcloud.io wss://tops.iexcloud.io wss://api.iexcloud.io wss://iexcloud.io
-            https://api-iam.intercom.io/messenger/ https://nexus-websocket-a.intercom.io/
-            https://nexus-websocket-b.intercom.io/ wss://nexus-websocket-a.intercom.io/
-            wss://nexus-websocket-b.intercom.io/ https://www.google-analytics.com; script-src
-            'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/api.js
-            https://www.google-analytics.com https://js.stripe.com/v3/ https://widget.intercom.io/widget/lhos563b
-            https://js.intercomcdn.com/ https://www.googletagmanager.com;"
-        X-Content-Security-Policy:
-          - "default-src 'self'; child-src 'none'; object-src 'self'; style-src
-            'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self'
-            https://js.intercomcdn.com/fonts/ https://fonts.gstatic.com; frame-src 'self'
-            https://portal.productboard.com/ https://js.stripe.com/; img-src 'self'
-            data: https://*.intercomcdn.com/ https://static.intercomassets.com/ https://www.google-analytics.com
-            https://downloads.intercomcdn.com/; connect-src 'self' https://auth.iexcloud.io
-            https://api.iexcloud.io https://api.iexcloud.io https://cloud.iexapis.com
-            wss://iexcloud.io wss://tops.iexcloud.io wss://api.iexcloud.io wss://iexcloud.io
-            https://api-iam.intercom.io/messenger/ https://nexus-websocket-a.intercom.io/
-            https://nexus-websocket-b.intercom.io/ wss://nexus-websocket-a.intercom.io/
-            wss://nexus-websocket-b.intercom.io/ https://www.google-analytics.com; script-src
-            'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/api.js
-            https://www.google-analytics.com https://js.stripe.com/v3/ https://widget.intercom.io/widget/lhos563b
-            https://js.intercomcdn.com/ https://www.googletagmanager.com;"
-        Frame-Options:
-          - SAMEORIGIN
-        X-Frame-Options:
-          - SAMEORIGIN
+          - ctoken=ef64ea7432894da3a5df0d13ec3a1d5a; Max-Age=43200; Path=/; Expires=Fri,
+            03 May 2019 00:12:52 GMT
         Strict-Transport-Security:
           - max-age=15768000
         Access-Control-Allow-Origin:
@@ -79,5 +45,5 @@ http_interactions:
         encoding: ASCII-8BIT
         string: Unknown symbol
       http_version:
-    recorded_at: Fri, 05 Apr 2019 11:12:07 GMT
+    recorded_at: Thu, 02 May 2019 12:12:52 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/iex/key_stats/msft.yml
+++ b/spec/fixtures/iex/key_stats/msft.yml
@@ -7,12 +7,12 @@ http_interactions:
         encoding: US-ASCII
         string: ""
       headers:
+        Accept:
+          - application/json; charset=utf-8
         User-Agent:
-          - Faraday v0.15.4
+          - IEX Ruby Client/1.0.1
         Accept-Encoding:
           - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-        Accept:
-          - "*/*"
     response:
       status:
         code: 200
@@ -21,7 +21,7 @@ http_interactions:
         Server:
           - nginx
         Date:
-          - Fri, 05 Apr 2019 11:12:06 GMT
+          - Thu, 02 May 2019 12:12:04 GMT
         Content-Type:
           - application/json; charset=utf-8
         Transfer-Encoding:
@@ -29,42 +29,10 @@ http_interactions:
         Connection:
           - keep-alive
         Set-Cookie:
-          - ctoken=d97d88c8b53e4d2a8bb9f9dd1d48984f; Max-Age=43200; Path=/; Expires=Fri,
-            05 Apr 2019 23:12:06 GMT
-        Content-Security-Policy:
-          - "default-src 'self'; child-src 'none'; object-src 'self'; style-src
-            'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self'
-            https://js.intercomcdn.com/fonts/ https://fonts.gstatic.com; frame-src 'self'
-            https://portal.productboard.com/ https://js.stripe.com/; img-src 'self'
-            data: https://*.intercomcdn.com/ https://static.intercomassets.com/ https://www.google-analytics.com
-            https://downloads.intercomcdn.com/; connect-src 'self' https://auth.iexcloud.io
-            https://api.iexcloud.io https://api.iexcloud.io https://cloud.iexapis.com
-            wss://iexcloud.io wss://tops.iexcloud.io wss://api.iexcloud.io wss://iexcloud.io
-            https://api-iam.intercom.io/messenger/ https://nexus-websocket-a.intercom.io/
-            https://nexus-websocket-b.intercom.io/ wss://nexus-websocket-a.intercom.io/
-            wss://nexus-websocket-b.intercom.io/ https://www.google-analytics.com; script-src
-            'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/api.js
-            https://www.google-analytics.com https://js.stripe.com/v3/ https://widget.intercom.io/widget/lhos563b
-            https://js.intercomcdn.com/ https://www.googletagmanager.com;"
-        X-Content-Security-Policy:
-          - "default-src 'self'; child-src 'none'; object-src 'self'; style-src
-            'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self'
-            https://js.intercomcdn.com/fonts/ https://fonts.gstatic.com; frame-src 'self'
-            https://portal.productboard.com/ https://js.stripe.com/; img-src 'self'
-            data: https://*.intercomcdn.com/ https://static.intercomassets.com/ https://www.google-analytics.com
-            https://downloads.intercomcdn.com/; connect-src 'self' https://auth.iexcloud.io
-            https://api.iexcloud.io https://api.iexcloud.io https://cloud.iexapis.com
-            wss://iexcloud.io wss://tops.iexcloud.io wss://api.iexcloud.io wss://iexcloud.io
-            https://api-iam.intercom.io/messenger/ https://nexus-websocket-a.intercom.io/
-            https://nexus-websocket-b.intercom.io/ wss://nexus-websocket-a.intercom.io/
-            wss://nexus-websocket-b.intercom.io/ https://www.google-analytics.com; script-src
-            'self' 'unsafe-inline' 'unsafe-eval' https://www.google.com/recaptcha/api.js
-            https://www.google-analytics.com https://js.stripe.com/v3/ https://widget.intercom.io/widget/lhos563b
-            https://js.intercomcdn.com/ https://www.googletagmanager.com;"
-        Frame-Options:
-          - SAMEORIGIN
-        X-Frame-Options:
-          - SAMEORIGIN
+          - ctoken=8df9fdfb440744638edd9bfdc8e0d27b; Max-Age=43200; Path=/; Expires=Fri,
+            03 May 2019 00:12:04 GMT
+        Iexcloud-Messages-Used:
+          - "5"
         X-Content-Type-Options:
           - nosniff
         Strict-Transport-Security:
@@ -80,8 +48,8 @@ http_interactions:
       body:
         encoding: ASCII-8BIT
         string:
-          '{"week52change":0.292055,"week52high":120.82,"week52low":89.48,"marketcap":915754985600,"employees":131000,"day200MovingAvg":108.04,"day50MovingAvg":111.56,"float":7541169096,"avg10Volume":23716223.6,"avg30Volume":26552395.97,"ttmEPS":4.35,"ttmDividendRate":1.76,"companyName":"Microsoft
-          Corp.","sharesOutstanding":7672210000,"maxChangePercent":3.901848,"year5ChangePercent":1.998995,"year2ChangePercent":0.820622,"year1ChangePercent":0.292055,"ytdChangePercent":0.18038,"month6ChangePercent":0.064479,"month3ChangePercent":0.169508,"month1ChangePercent":0.068577,"day30ChangePercent":0.075606,"day5ChangePercent":0.01204,"nextDividendRate":null,"nextDividendDate":"2019-05-15","dividendYield":0.014745308310991957,"nextEarningsDate":"2019-04-25","exDividendDate":"2019-05-15","peRatio":27.44}'
+          '{"week52change":0.371641,"week52high":136.04,"week52low":95.92,"marketcap":990869169557,"employees":133074,"day200MovingAvg":112.43,"day50MovingAvg":121,"float":7694414092,"avg10Volume":25160156.2,"avg30Volume":23123700.13,"ttmEPS":4.66,"ttmDividendRate":1.8,"companyName":"Microsoft
+          Corp.","sharesOutstanding":7849945172,"maxChangePercent":4.355607,"year5ChangePercent":2.32987,"year2ChangePercent":0.84983,"year1ChangePercent":0.383503,"ytdChangePercent":0.270151,"month6ChangePercent":0.208977,"month3ChangePercent":0.212188,"month1ChangePercent":0.076335,"day30ChangePercent":0.089589,"day5ChangePercent":-0.010013,"nextDividendDate":"2019-05-21","dividendYield":0.014087248841960684,"nextEarningsDate":"2019-07-29","exDividendDate":"2019-05-24","peRatio":29.47,"beta":1.4135449089973444}'
       http_version:
-    recorded_at: Fri, 05 Apr 2019 11:12:06 GMT
+    recorded_at: Thu, 02 May 2019 12:12:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/iex/endpoints/key_stats_spec.rb
+++ b/spec/iex/endpoints/key_stats_spec.rb
@@ -9,44 +9,56 @@ describe IEX::Resources::KeyStats do
     end
     it 'retrieves a keyStats' do
       expect(subject.company_name).to eq 'Microsoft Corp.'
-      expect(subject.market_cap).to eq 915_754_985_600
-      expect(subject.market_cap_dollars).to eq '$915,754,985,600'
+      expect(subject.market_cap).to eq 990_869_169_557
+      expect(subject.market_cap_dollars).to eq '$990,869,169,557'
+      expect(subject.employees).to eq 133_074
     end
 
     it 'weekly stats' do
-      expect(subject.week_52_high).to eq 120.82
-      expect(subject.week_52_high_dollar).to eq '$120.82'
-      expect(subject.week_52_low).to eq 89.48
-      expect(subject.week_52_low_dollar).to eq '$89.48'
-      expect(subject.week_52_change_dollar).to eq '$0.29'
+      expect(subject.week_52_high).to eq 136.04
+      expect(subject.week_52_high_dollar).to eq '$136.04'
+      expect(subject.week_52_low).to eq 95.92
+      expect(subject.week_52_low_dollar).to eq '$95.92'
+      expect(subject.week_52_change_dollar).to eq '$0.37'
     end
 
     it 'general stats' do
-      expect(subject.dividend_yield).to eq 0.014745308310991957
-      expect(subject.ex_dividend_date).to eq '2019-05-15'
-      expect(subject.shares_outstanding).to eq 7_672_210_000
-      expect(subject.float).to eq 7_541_169_096
-      expect(subject.ttm_eps).to eq 4.35
-      expect(subject.day_200_moving_avg).to eq 108.04
-      expect(subject.day_50_moving_avg).to eq 111.56
+      expect(subject.ttm_dividend_rate).to eq 1.8
+      expect(subject.dividend_yield).to eq 0.014087248841960684
+      expect(subject.ex_dividend_date).to eq '2019-05-24'
+      expect(subject.shares_outstanding).to eq 7_849_945_172
+      expect(subject.float).to eq 7_694_414_092
+      expect(subject.ttm_eps).to eq 4.66
+      expect(subject.next_dividend_date).to eq '2019-05-21'
+      expect(subject.next_earnings_date).to eq '2019-07-29'
+      expect(subject.pe_ratio).to eq 29.47
+      expect(subject.beta).to eq 1.4135449089973444
+      expect(subject.day_200_moving_avg).to eq 112.43
+      expect(subject.day_50_moving_avg).to eq 121
     end
 
     it 'changes stats' do
-      expect(subject.year_5_change_percent).to be 1.998995
-      expect(subject.year_5_change_percent_s).to eq '+199.90%'
-      expect(subject.year_2_change_percent).to eq 0.820622
-      expect(subject.year_2_change_percent_s).to eq '+82.06%'
-      expect(subject.year_1_change_percent).to eq 0.292055
-      expect(subject.year_1_change_percent_s).to eq '+29.21%'
-      expect(subject.ytd_change_percent).to eq 0.18038
-      expect(subject.month_6_change_percent).to eq 0.064479
-      expect(subject.month_6_change_percent_s).to eq '+6.45%'
-      expect(subject.month_3_change_percent).to eq 0.169508
-      expect(subject.month_3_change_percent_s).to eq '+16.95%'
-      expect(subject.month_1_change_percent).to eq 0.068577
-      expect(subject.month_1_change_percent_s).to eq '+6.86%'
-      expect(subject.day_5_change_percent).to eq 0.01204
-      expect(subject.day_5_change_percent_s).to eq '+1.20%'
+      expect(subject.avg_10_volume).to be 25_160_156.2
+      expect(subject.avg_30_volume).to be 23_123_700.13
+      expect(subject.max_change_percent).to eq 4.355607
+      expect(subject.year_5_change_percent).to be 2.32987
+      expect(subject.year_5_change_percent_s).to eq '+232.99%'
+      expect(subject.year_2_change_percent).to eq 0.84983
+      expect(subject.year_2_change_percent_s).to eq '+84.98%'
+      expect(subject.year_1_change_percent).to eq 0.383503
+      expect(subject.year_1_change_percent_s).to eq '+38.35%'
+      expect(subject.ytd_change_percent).to eq 0.270151
+      expect(subject.ytd_change_percent_s).to eq '+27.02%'
+      expect(subject.month_6_change_percent).to eq 0.208977
+      expect(subject.month_6_change_percent_s).to eq '+20.90%'
+      expect(subject.month_3_change_percent).to eq 0.212188
+      expect(subject.month_3_change_percent_s).to eq '+21.22%'
+      expect(subject.month_1_change_percent).to eq 0.076335
+      expect(subject.month_1_change_percent_s).to eq '+7.63%'
+      expect(subject.day_5_change_percent).to eq(-0.010013)
+      expect(subject.day_5_change_percent_s).to eq '-1.00%'
+      expect(subject.day_30_change_percent).to eq 0.089589
+      expect(subject.day_30_change_percent_s).to eq '+8.96%'
     end
   end
 


### PR DESCRIPTION
Address to issue: https://github.com/dblock/iex-ruby-client/issues/49

Add missing properties for key stats API: 

Missing properties list:
```ruby
      property 'employees'
      property 'avg_10_volume', from: 'avg10Volume'
      property 'avg_30_volume', from: 'avg30Volume'
      property 'ttm_dividend_rate', from: 'ttmDividendRate'
      property 'max_change_percent', from: 'maxChangePercent'
      property 'day_30_change_percent', from: 'day30ChangePercent'
      property 'day_30_change_percent_s', from: 'day30ChangePercent', with: ->(v) { Resource.float_to_percentage(v) }
      property 'next_dividend_date', from: 'nextDividendDate'
      property 'next_earnings_date', from: 'nextEarningsDate'
      property 'pe_ratio', from: 'peRatio'
      property 'beta'
```