### PR TITLE
Fix income endpoint if the API returns no result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.1.1 (Next)
 
 * Your contribution here.
+* [#61](https://github.com/dblock/iex-ruby-client/pull/61): Fix income endpoint if the api returns no result - [@brunjo](https://github.com/brunjo).
 * [#57](https://github.com/dblock/iex-ruby-client/pull/57): Update properties for chart api endpoint - [@brunjo](https://github.com/brunjo).
 
 ### 1.1.0 (2019/07/08)

--- a/lib/iex/endpoints/income.rb
+++ b/lib/iex/endpoints/income.rb
@@ -2,7 +2,7 @@ module IEX
   module Endpoints
     module Income
       def income(symbol, options = {})
-        get("stock/#{symbol}/income", options)['income'].map do |data|
+        (get("stock/#{symbol}/income", options)['income'] || []).map do |data|
           IEX::Resources::Income.new(data)
         end
       rescue Faraday::ResourceNotFound => e

--- a/spec/fixtures/iex/income/invalid.yml
+++ b/spec/fixtures/iex/income/invalid.yml
@@ -1,49 +1,49 @@
 ---
 http_interactions:
-  - request:
-      method: get
-      uri: https://cloud.iexapis.com/v1/stock/INVALID/earnings?token=test-iex-api-publishable-token
-      body:
-        encoding: US-ASCII
-        string: ""
-      headers:
-        Accept:
-          - application/json; charset=utf-8
-        User-Agent:
-          - IEX Ruby Client/1.0.1
-        Accept-Encoding:
-          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-    response:
-      status:
-        code: 404
-        message: Not Found
-      headers:
-        Server:
-          - nginx
-        Date:
-          - Mon, 08 Jul 2019 05:44:19 GMT
-        Content-Type:
-          - text/html; charset=utf-8
-        Transfer-Encoding:
-          - chunked
-        Connection:
-          - keep-alive
-        Set-Cookie:
-          - ctoken=5eb12a74846a4e03b399e201d6853f6a; Max-Age=43200; Path=/; Expires=Mon,
-            08 Jul 2019 17:44:19 GMT
-        Strict-Transport-Security:
-          - max-age=15768000
-        Access-Control-Allow-Origin:
-          - "*"
-        Access-Control-Allow-Credentials:
-          - "true"
-        Access-Control-Allow-Methods:
-          - GET, OPTIONS
-        Access-Control-Allow-Headers:
-          - Origin, X-Requested-With, Content-Type, Accept
-      body:
-        encoding: ASCII-8BIT
-        string: Unknown symbol
-      http_version:
-    recorded_at: Mon, 08 Jul 2019 05:44:19 GMT
-recorded_with: VCR 4.0.0
+- request:
+    method: get
+    uri: https://cloud.iexapis.com/v1/stock/INVALID/income?token=test-iex-api-publishable-token
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - IEX Ruby Client/1.1.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 31 Jan 2020 23:27:10 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - ctoken=8a37f605f30c430cbacbe804d3c9816f; Max-Age=43200; Path=/; Expires=Sat,
+        01 Feb 2020 11:27:10 GMT
+      Strict-Transport-Security:
+      - max-age=15768000
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+    body:
+      encoding: ASCII-8BIT
+      string: Unknown symbol
+    http_version:
+  recorded_at: Fri, 31 Jan 2020 23:27:10 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/iex/income/nsrgy.yml
+++ b/spec/fixtures/iex/income/nsrgy.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cloud.iexapis.com/v1/stock/nsrgy/income?token=test-iex-api-publishable-token
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      User-Agent:
+      - IEX Ruby Client/1.1.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 31 Jan 2020 23:24:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - ctoken=89c0198f95cf496092454e8c8afc0d4a; Max-Age=43200; Path=/; Expires=Sat,
+        01 Feb 2020 11:24:06 GMT
+      Iexcloud-Messages-Used:
+      - '0'
+      Iexcloud-Premium-Messages-Used:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version:
+  recorded_at: Fri, 31 Jan 2020 23:24:06 GMT
+recorded_with: VCR 5.0.0

--- a/spec/iex/endpoints/income_spec.rb
+++ b/spec/iex/endpoints/income_spec.rb
@@ -48,6 +48,15 @@ describe IEX::Resources::Income do
     end
   end
 
+  context 'no result', vcr: { cassette_name: 'income/nsrgy' } do
+    subject do
+      client.income('nsrgy')
+    end
+    it 'returns empty array' do
+      expect(subject).to eq []
+    end
+  end
+
   context 'invalid symbol', vcr: { cassette_name: 'income/invalid' } do
     subject do
       client.income('INVALID')

--- a/spec/iex/endpoints/income_spec.rb
+++ b/spec/iex/endpoints/income_spec.rb
@@ -50,7 +50,7 @@ describe IEX::Resources::Income do
 
   context 'invalid symbol', vcr: { cassette_name: 'income/invalid' } do
     subject do
-      client.earnings('INVALID')
+      client.income('INVALID')
     end
     it 'fails with SymbolNotFoundError' do
       expect { subject }.to raise_error IEX::Errors::SymbolNotFoundError, 'Symbol INVALID Not Found'


### PR DESCRIPTION
`client.income('nsrgy')` returned the following error because the API doesn't return any results.

```
NoMethodError (undefined method `map' for nil:NilClass)
```