### PR TITLE
Add required ruby version to gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.1.2 (Next)
 
+* Your contribution here.
 * [#67](https://github.com/dblock/iex-ruby-client/pull/67): Add required ruby version to gemspec - [@wdperson](https://github.com/wdperson).
 * [#66](https://github.com/dblock/iex-ruby-client/pull/66): Fix: KeyStats#week_52_change always returns nil - [@brunjo](https://github.com/brunjo).
 * [#65](https://github.com/dblock/iex-ruby-client/pull/65): Add stock_market_list - [@bguban](https://github.com/bguban).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 1.1.2 (Next)
 
-* Your contribution here.
+* [#67](https://github.com/dblock/iex-ruby-client/pull/67): Add required ruby version to gemspec - [@wdperson](https://github.com/wdperson).
 * [#66](https://github.com/dblock/iex-ruby-client/pull/66): Fix: KeyStats#week_52_change always returns nil - [@brunjo](https://github.com/brunjo).
 * [#65](https://github.com/dblock/iex-ruby-client/pull/65): Add stock_market_list - [@bguban](https://github.com/bguban).
 * [#64](https://github.com/dblock/iex-ruby-client/pull/64): Add ref_data_isin - [@bguban](https://github.com/bguban).

--- a/iex-ruby-client.gemspec
+++ b/iex-ruby-client.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |s|
   s.email = 'dblock@dblock.org'
   s.platform = Gem::Platform::RUBY
   s.required_rubygems_version = '>= 1.3.6'
+  s.required_ruby_version = '>= 2.3.0'
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']


### PR DESCRIPTION
This adds the required ruby version to the .gemspec file.  This should resolve issue #60: https://github.com/dblock/iex-ruby-client/issues/60