### PR TITLE
Fix ref_data_isin request with wrong isin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.1.2 (Next)
 
 * Your contribution here.
+* [#68](https://github.com/dblock/iex-ruby-client/pull/68): Fix ref_data_isin request with wrong isin - [@bguban](https://github.com/bguban).
 * [#67](https://github.com/dblock/iex-ruby-client/pull/67): Add required ruby version to gemspec - [@wdperson](https://github.com/wdperson).
 * [#66](https://github.com/dblock/iex-ruby-client/pull/66): Fix: KeyStats#week_52_change always returns nil - [@brunjo](https://github.com/brunjo).
 * [#65](https://github.com/dblock/iex-ruby-client/pull/65): Add stock_market_list - [@bguban](https://github.com/bguban).

--- a/lib/iex/endpoints/ref_data.rb
+++ b/lib/iex/endpoints/ref_data.rb
@@ -6,7 +6,7 @@ module IEX
 
         if response.is_a?(Hash) # mapped option was set
           response.transform_values do |rows|
-            rows.map { |row| IEX::Resources::Symbol.new(row) }
+            rows&.map { |row| IEX::Resources::Symbol.new(row) }
           end
         else
           response.map { |row| IEX::Resources::Symbol.new(row) }

--- a/spec/fixtures/iex/ref-data/wrong_isin_mapped.yml
+++ b/spec/fixtures/iex/ref-data/wrong_isin_mapped.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://cloud.iexapis.com/v1/ref-data/isin
+    body:
+      encoding: UTF-8
+      string: '{"token":"test-iex-api-publishable-token","isin":["WRONG12345"],"mapped":true}'
+    headers:
+      Accept:
+      - application/json; charset=utf-8
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - IEX Ruby Client/1.1.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Wed, 25 Mar 2020 10:15:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '19'
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - ctoken=9ddb19d57dea471f9855bacdb85a96a5; Max-Age=43200; Path=/; Expires=Wed,
+        25 Mar 2020 22:15:28 GMT
+      Iexcloud-Messages-Used:
+      - '100'
+      Iexcloud-Premium-Messages-Used:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      Strict-Transport-Security:
+      - max-age=15768000
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept
+    body:
+      encoding: UTF-8
+      string: '{"WRONG12345":null}'
+    http_version: null
+  recorded_at: Wed, 25 Mar 2020 10:15:28 GMT
+recorded_with: VCR 5.1.0

--- a/spec/iex/endpoints/ref_data_spec.rb
+++ b/spec/iex/endpoints/ref_data_spec.rb
@@ -27,6 +27,14 @@ describe IEX::Api::Client do
         expect(subject['US5949181045'][1]).to eq('exchange' => 'ETR', 'iex_id' => 'IEX_4C42583859482D52', 'region' => 'DE', 'symbol' => 'MSF-GY')
         expect(subject['US5949181045'][2]).to eq('exchange' => 'BRU', 'iex_id' => 'IEX_5833345950432D52', 'region' => 'BE', 'symbol' => 'MSF-BB')
       end
+
+      context 'with wrong ISIN', vcr: { cassette_name: 'ref-data/wrong_isin_mapped' } do
+        subject { client.ref_data_isin(%w[WRONG12345], mapped: true) }
+
+        it 'returns nil value for given ISIN' do
+          expect(subject).to eq('WRONG12345' => nil)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When given ISIN is wrong IEX cloud returns `null` as value for given ISIN that breaks the response parser.