### PR TITLE
Fixed ref_data_isin request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.1.3 (Next)
 
 * Your contribution here.
+* [#69](https://github.com/dblock/iex-ruby-client/pull/69): Fixed ref_data_isin request - [@bguban](https://github.com/bguban).
 
 ### 1.1.2 (2020/03/25)
 

--- a/lib/iex/endpoints/ref_data.rb
+++ b/lib/iex/endpoints/ref_data.rb
@@ -2,7 +2,7 @@ module IEX
   module Endpoints
     module RefData
       def ref_data_isin(isins, options = {})
-        response = post('ref-data/isin', { token: publishable_token, isin: isins }.merge(options))
+        response = get('ref-data/isin', { token: publishable_token, isin: isins.join(',') }.merge(options))
 
         if response.is_a?(Hash) # mapped option was set
           response.transform_values do |rows|

--- a/spec/fixtures/iex/ref-data/isin.yml
+++ b/spec/fixtures/iex/ref-data/isin.yml
@@ -1,18 +1,18 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://cloud.iexapis.com/v1/ref-data/isin
+    method: get
+    uri: https://cloud.iexapis.com/v1/ref-data/isin?isin=US0378331005&token=test-iex-api-publishable-token
     body:
-      encoding: UTF-8
-      string: '{"isin":["US0378331005"],"token":"test-iex-api-publishable-token"}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept:
       - application/json; charset=utf-8
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - IEX Ruby Client/1.1.1
+      - IEX Ruby Client/1.1.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 26 Feb 2020 20:04:36 GMT
+      - Fri, 10 Apr 2020 15:17:33 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -31,8 +31,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=6b0870d7654f4742a9458a86f537ae8b; Max-Age=43200; Path=/; Expires=Thu,
-        27 Feb 2020 08:04:36 GMT
+      - ctoken=b1f966fa60964069a7d948021e2c2149; Max-Age=43200; Path=/; Expires=Sat,
+        11 Apr 2020 03:17:32 GMT
       Iexcloud-Messages-Used:
       - '100'
       Iexcloud-Premium-Messages-Used:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '[{"symbol":"AAPL","region":"US","exchange":"NAS","iexId":"IEX_4D48333344362D52"},{"symbol":"APC-GY","region":"DE","exchange":"ETR","iexId":"IEX_464D46474C312D52"}]'
     http_version: null
-  recorded_at: Wed, 26 Feb 2020 20:04:36 GMT
+  recorded_at: Fri, 10 Apr 2020 15:17:33 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/iex/ref-data/isin_mapped.yml
+++ b/spec/fixtures/iex/ref-data/isin_mapped.yml
@@ -1,18 +1,18 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://cloud.iexapis.com/v1/ref-data/isin
+    method: get
+    uri: https://cloud.iexapis.com/v1/ref-data/isin?isin=US0378331005,US5949181045&mapped=true&token=test-iex-api-publishable-token
     body:
-      encoding: UTF-8
-      string: '{"token":"test-iex-api-publishable-token","isin":["US0378331005","US5949181045"],"mapped":true}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept:
       - application/json; charset=utf-8
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - IEX Ruby Client/1.1.2
+      - IEX Ruby Client/1.1.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 04 Mar 2020 09:45:05 GMT
+      - Fri, 10 Apr 2020 15:17:33 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -31,8 +31,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=b93327e2c9b4432f9c7ecb36396dcd4c; Max-Age=43200; Path=/; Expires=Wed,
-        04 Mar 2020 21:45:05 GMT
+      - ctoken=49bd808852194ac59e3551620bd7c4b2; Max-Age=43200; Path=/; Expires=Sat,
+        11 Apr 2020 03:17:33 GMT
       Iexcloud-Messages-Used:
       - '100'
       Iexcloud-Premium-Messages-Used:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: ASCII-8BIT
       string: '{"US0378331005":[{"symbol":"AAPL","region":"US","exchange":"NAS","iexId":"IEX_4D48333344362D52"},{"symbol":"APC-GY","region":"DE","exchange":"ETR","iexId":"IEX_464D46474C312D52"}],"US5949181045":[{"symbol":"MSFT","region":"US","exchange":"NAS","iexId":"IEX_5038523343322D52"},{"symbol":"MSF-GY","region":"DE","exchange":"ETR","iexId":"IEX_4C42583859482D52"},{"symbol":"MSF-BB","region":"BE","exchange":"BRU","iexId":"IEX_5833345950432D52"}]}'
     http_version: null
-  recorded_at: Wed, 04 Mar 2020 09:45:05 GMT
+  recorded_at: Fri, 10 Apr 2020 15:17:33 GMT
 recorded_with: VCR 5.1.0

--- a/spec/fixtures/iex/ref-data/wrong_isin_mapped.yml
+++ b/spec/fixtures/iex/ref-data/wrong_isin_mapped.yml
@@ -1,18 +1,18 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://cloud.iexapis.com/v1/ref-data/isin
+    method: get
+    uri: https://cloud.iexapis.com/v1/ref-data/isin?isin=WRONG12345&mapped=true&token=test-iex-api-publishable-token
     body:
-      encoding: UTF-8
-      string: '{"token":"test-iex-api-publishable-token","isin":["WRONG12345"],"mapped":true}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Accept:
       - application/json; charset=utf-8
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
-      - IEX Ruby Client/1.1.2
+      - IEX Ruby Client/1.1.3
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -23,7 +23,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 25 Mar 2020 10:15:28 GMT
+      - Fri, 10 Apr 2020 15:17:34 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -31,8 +31,8 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - ctoken=9ddb19d57dea471f9855bacdb85a96a5; Max-Age=43200; Path=/; Expires=Wed,
-        25 Mar 2020 22:15:28 GMT
+      - ctoken=84910330e5ea4058969d0af364c32947; Max-Age=43200; Path=/; Expires=Sat,
+        11 Apr 2020 03:17:34 GMT
       Iexcloud-Messages-Used:
       - '100'
       Iexcloud-Premium-Messages-Used:
@@ -53,5 +53,5 @@ http_interactions:
       encoding: UTF-8
       string: '{"WRONG12345":null}'
     http_version: null
-  recorded_at: Wed, 25 Mar 2020 10:15:28 GMT
+  recorded_at: Fri, 10 Apr 2020 15:17:34 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
IEX cloud changed its endpoint https://iexcloud.io/docs/api/#isin-mapping. Now they expect GET requests instead of POST. 
<img width="637" alt="Screen Shot 2020-04-10 at 6 25 53 PM" src="https://user-images.githubusercontent.com/1564376/79002263-c3c49400-7b58-11ea-8933-7f1ee668a5d5.png">
