### PR TITLE
Add type cast for ref_data when parameter is string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 1.2.1 (Next)
 
 * [#82](https://github.com/dblock/iex-ruby-client/pull/82): Added `config.referer` to set HTTP `Referer` header. This enables IEX's "Manage domains" domain locking for tokens - [@agrberg](https://github.com/agrberg).
-* [#70](https://github.com/dblock/iex-ruby-client/pull/70): Add type safe cast when ref_data_isin parameter is string - [@rodolfobandeira](https://github.com/rodolfobandeira).
+* [#70](https://github.com/dblock/iex-ruby-client/pull/70): Added support for `ref_data_isin` taking a single `String` parameter - [@rodolfobandeira](https://github.com/rodolfobandeira).
 * Your contribution here.
 
 ### 1.2.0 (2020/09/01)
@@ -10,7 +10,6 @@
 * [#71](https://github.com/dblock/iex-ruby-client/pull/71): Added `symbols` resource - [@ryosuke-endo](https://github.com/ryosuke-endo).
 * [#69](https://github.com/dblock/iex-ruby-client/pull/69): Fixed `ref_data_isin` request - [@bguban](https://github.com/bguban).
 * [#72](https://github.com/dblock/iex-ruby-client/pull/72): Cache `Faraday::Connection` for persistent adapters - [@dblock](https://github.com/dblock).
-* [#69](https://github.com/dblock/iex-ruby-client/pull/69): Fixed ref_data_isin request - [@bguban](https://github.com/bguban).
 
 ### 1.1.2 (2020/03/25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.2.1 (Next)
 
 * [#82](https://github.com/dblock/iex-ruby-client/pull/82): Added `config.referer` to set HTTP `Referer` header. This enables IEX's "Manage domains" domain locking for tokens - [@agrberg](https://github.com/agrberg).
+* [#70](https://github.com/dblock/iex-ruby-client/pull/70): Add type safe cast when ref_data_isin parameter is string - [@rodolfobandeira](https://github.com/rodolfobandeira).
 * Your contribution here.
 
 ### 1.2.0 (2020/09/01)
@@ -9,6 +10,7 @@
 * [#71](https://github.com/dblock/iex-ruby-client/pull/71): Added `symbols` resource - [@ryosuke-endo](https://github.com/ryosuke-endo).
 * [#69](https://github.com/dblock/iex-ruby-client/pull/69): Fixed `ref_data_isin` request - [@bguban](https://github.com/bguban).
 * [#72](https://github.com/dblock/iex-ruby-client/pull/72): Cache `Faraday::Connection` for persistent adapters - [@dblock](https://github.com/dblock).
+* [#69](https://github.com/dblock/iex-ruby-client/pull/69): Fixed ref_data_isin request - [@bguban](https://github.com/bguban).
 
 ### 1.1.2 (2020/03/25)
 

--- a/README.md
+++ b/README.md
@@ -378,19 +378,23 @@ See [#crypto](https://iexcloud.io/docs/api/#crypto) for detailed documentation o
 
 ### ISIN Mapping
 
-Converts ISIN to IEX Cloud symbols.
+Convert ISIN to IEX Cloud symbols.
 
 ```ruby
-symbols = client.ref_data_isin(['US0378331005'])
-
-# You can also pass single elements as string:
-# symbols = client.ref_data_isin('US0378331005')
+symbols = client.ref_data_isin('US0378331005')
 
 symbols.first.exchange # NAS
 symbols.first.iex_id # IEX_4D48333344362D52
 symbols.first.region # US
 symbols.first.symbol # AAPL
 ```
+
+The API also lets you convert multiple ISINs to IEX Cloud symbols.
+
+```ruby
+symbols = client.ref_data_isin(['US0378331005', 'US0378331006'])
+```
+
 
 You can use `mapped: true` option to receive symbols grouped by their ISINs.
 

--- a/README.md
+++ b/README.md
@@ -383,6 +383,9 @@ Converts ISIN to IEX Cloud symbols.
 ```ruby
 symbols = client.ref_data_isin(['US0378331005'])
 
+# You can also pass single elements as string:
+# symbols = client.ref_data_isin('US0378331005')
+
 symbols.first.exchange # NAS
 symbols.first.iex_id # IEX_4D48333344362D52
 symbols.first.region # US

--- a/lib/iex/endpoints/ref_data.rb
+++ b/lib/iex/endpoints/ref_data.rb
@@ -2,7 +2,7 @@ module IEX
   module Endpoints
     module RefData
       def ref_data_isin(isins, options = {})
-        response = get('ref-data/isin', { token: publishable_token, isin: isins.join(',') }.merge(options))
+        response = get('ref-data/isin', { token: publishable_token, isin: Array(isins).join(',') }.merge(options))
 
         if response.is_a?(Hash) # mapped option was set
           response.transform_values do |rows|

--- a/spec/iex/endpoints/ref_data_spec.rb
+++ b/spec/iex/endpoints/ref_data_spec.rb
@@ -36,6 +36,15 @@ describe IEX::Api::Client do
         end
       end
     end
+
+    context 'graciously handle parameter as string', vcr: { cassette_name: 'ref-data/isin' } do
+      subject { client.ref_data_isin('US0378331005') }
+
+      it 'converts ISIN from string to Array and do not errors out' do
+        expect { subject }.not_to raise_error
+        expect(subject.count).to eq(2)
+      end
+    end
   end
 
   describe '#ref_data_symbols', vcr: { cassette_name: 'ref-data/symbols' } do

--- a/spec/iex/endpoints/ref_data_spec.rb
+++ b/spec/iex/endpoints/ref_data_spec.rb
@@ -14,6 +14,16 @@ describe IEX::Api::Client do
       end
     end
 
+    context 'graciously handle parameter as string', vcr: { cassette_name: 'ref-data/isin' } do
+      subject { client.ref_data_isin('US0378331005') }
+
+      it 'converts ISIN to IEX Cloud symbols' do
+        expect(subject.count).to eq(2)
+        expect(subject.first).to eq('exchange' => 'NAS', 'iex_id' => 'IEX_4D48333344362D52', 'region' => 'US', 'symbol' => 'AAPL')
+        expect(subject.last).to eq('exchange' => 'ETR', 'iex_id' => 'IEX_464D46474C312D52', 'region' => 'DE', 'symbol' => 'APC-GY')
+      end
+    end
+
     context 'with mapped option', vcr: { cassette_name: 'ref-data/isin_mapped' } do
       subject { client.ref_data_isin(%w[US0378331005 US5949181045], mapped: true) }
 
@@ -27,22 +37,13 @@ describe IEX::Api::Client do
         expect(subject['US5949181045'][1]).to eq('exchange' => 'ETR', 'iex_id' => 'IEX_4C42583859482D52', 'region' => 'DE', 'symbol' => 'MSF-GY')
         expect(subject['US5949181045'][2]).to eq('exchange' => 'BRU', 'iex_id' => 'IEX_5833345950432D52', 'region' => 'BE', 'symbol' => 'MSF-BB')
       end
-
-      context 'with wrong ISIN', vcr: { cassette_name: 'ref-data/wrong_isin_mapped' } do
-        subject { client.ref_data_isin(%w[WRONG12345], mapped: true) }
-
-        it 'returns nil value for given ISIN' do
-          expect(subject).to eq('WRONG12345' => nil)
-        end
-      end
     end
 
-    context 'graciously handle parameter as string', vcr: { cassette_name: 'ref-data/isin' } do
-      subject { client.ref_data_isin('US0378331005') }
+    context 'with wrong ISIN', vcr: { cassette_name: 'ref-data/wrong_isin_mapped' } do
+      subject { client.ref_data_isin(%w[WRONG12345], mapped: true) }
 
-      it 'converts ISIN from string to Array and do not errors out' do
-        expect { subject }.not_to raise_error
-        expect(subject.count).to eq(2)
+      it 'returns nil value for given ISIN' do
+        expect(subject).to eq('WRONG12345' => nil)
       end
     end
   end


### PR DESCRIPTION
Follow up on [your comment](https://github.com/dblock/iex-ruby-client/pull/69#discussion_r406972394) @dblock