### PR TITLE
Updated README to match API client.ohlc.get('MSFT') -> client.ohlc('MSFT')

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [#quote](https://iexcloud.io/docs/api/#quote) for detailed documentation or 
 Fetches a single stock OHLC price. Open and Close prices contain timestamp.
 
 ```ruby
-ohlc = client.ohlc.get('MSFT')
+ohlc = client.ohlc('MSFT')
 
 ohlc.close.price # 90.165
 ohlc.close.time #


### PR DESCRIPTION
I noticed that the README example for `IEX::Api::Client#ohlc` was no longer functional as there was an [update to the method to require the symbol to be passed](https://github.com/dblock/iex-ruby-client/blob/68959644b334d1a247d86e435c15b353fd5fda4f/lib/iex/endpoints/ohlc.rb#L4):

```ruby
[4] pry(main)> client.ohlc.get('MSFT')
ArgumentError: wrong number of arguments (given 0, expected 1..2)
from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/iex-ruby-client-1.1.2/lib/iex/endpoints/ohlc.rb:4:in `ohlc'
[5] pry(main)> client.ohlc('MSFT')
IEX::Errors::ClientError: The requested data is not available to free tier accounts. Please upgrade for access to this data.
from /home/travishooper/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/iex-ruby-client-1.1.2/lib/iex/cloud/response.rb:12:in `on_complete'
```