### PR TITLE
Add extended_change_percent and extended_change_percent_s to Quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 1.1.3 (Next)
 
 * Your contribution here.
+* [#78](https://github.com/dblock/iex-ruby-client/pull/78): Added `extended_change_percent` and `extended_change_percent_s` properties to Quote. - [@reddavis](https://github.com/reddavis).
 * [#71](https://github.com/dblock/iex-ruby-client/pull/71): Added `symbols` resource - [@ryosuke-endo](https://github.com/ryosuke-endo).
 * [#69](https://github.com/dblock/iex-ruby-client/pull/69): Fixed `ref_data_isin` request - [@bguban](https://github.com/bguban).
 * [#72](https://github.com/dblock/iex-ruby-client/pull/72): Cache `Faraday::Connection` for persistent adapters - [@dblock](https://github.com/dblock).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 1.1.3 (Next)
 
 * Your contribution here.
-* [#78](https://github.com/dblock/iex-ruby-client/pull/78): Added `extended_change_percent` and `extended_change_percent_s` properties to Quote. - [@reddavis](https://github.com/reddavis).
+* [#78](https://github.com/dblock/iex-ruby-client/pull/78): Added `Quote#extended_change_percent` and `Quote#extended_change_percent_s` properties to Quote - [@reddavis](https://github.com/reddavis).
 * [#71](https://github.com/dblock/iex-ruby-client/pull/71): Added `symbols` resource - [@ryosuke-endo](https://github.com/ryosuke-endo).
 * [#69](https://github.com/dblock/iex-ruby-client/pull/69): Fixed `ref_data_isin` request - [@bguban](https://github.com/bguban).
 * [#72](https://github.com/dblock/iex-ruby-client/pull/72): Cache `Faraday::Connection` for persistent adapters - [@dblock](https://github.com/dblock).

--- a/lib/iex/resources/quote.rb
+++ b/lib/iex/resources/quote.rb
@@ -24,8 +24,18 @@ module IEX
       property 'iex_last_updated_t', from: 'iexLastUpdated', with: ->(v) { v&.positive? ? Time.at(v / 1000) : nil } # last update time of the data
       property 'delayed_price', from: 'delayedPrice' # 15 minute delayed market price
       property 'delayed_price_time', from: 'delayedPriceTime' # time of the delayed market price
-      property 'extended_price', from: 'extendedPrice' # ?
-      property 'extended_price_time', from: 'extendedPriceTime' # ?
+      property 'extended_price', from: 'extendedPrice' # the pre market and post market price
+      property 'extended_change_percent', from: 'extendedChangePercent' # price change percent between extended_price and latest_price
+      property 'extended_change_percent_s', from: 'extendedChangePercent', with: lambda { |v|
+        if v
+          [
+            v.positive? ? '+' : '',
+            format('%.2f', (v * 100).round),
+            '%'
+          ].join
+        end
+      } # change in percent as a String with a leading + or - sign
+      property 'extended_price_time', from: 'extendedPriceTime' # the last update time of extended_price
       property 'previous_close', from: 'previousClose' # adjusted close price of the last trading day of the stock
       property 'change' # change in value, calculated using calculation_price from previous_close
       property 'change_percent', from: 'changePercent' # change in percent, calculated using calculation_price from previous_close

--- a/lib/iex/resources/quote.rb
+++ b/lib/iex/resources/quote.rb
@@ -30,7 +30,7 @@ module IEX
         if v
           [
             v.positive? ? '+' : '',
-            format('%.2f', (v * 100).round),
+            format('%.2f', v * 100),
             '%'
           ].join
         end

--- a/spec/iex/endpoints/quote_spec.rb
+++ b/spec/iex/endpoints/quote_spec.rb
@@ -19,7 +19,7 @@ describe IEX::Resources::Quote do
       expect(subject.change_percent).to eq(-0.00508)
       expect(subject.change_percent_s).to eq '-0.51%'
       expect(subject.extended_change_percent).to eq(-0.00008)
-      expect(subject.extended_change_percent_s).to eq '0.00%'
+      expect(subject.extended_change_percent_s).to eq '0.01%'
     end
     it 'coerces times' do
       expect(subject.latest_update).to eq 1_554_408_000_193

--- a/spec/iex/endpoints/quote_spec.rb
+++ b/spec/iex/endpoints/quote_spec.rb
@@ -19,7 +19,7 @@ describe IEX::Resources::Quote do
       expect(subject.change_percent).to eq(-0.00508)
       expect(subject.change_percent_s).to eq '-0.51%'
       expect(subject.extended_change_percent).to eq(-0.00008)
-      expect(subject.extended_change_percent_s).to eq '0.01%'
+      expect(subject.extended_change_percent_s).to eq '-0.01%'
     end
     it 'coerces times' do
       expect(subject.latest_update).to eq 1_554_408_000_193

--- a/spec/iex/endpoints/quote_spec.rb
+++ b/spec/iex/endpoints/quote_spec.rb
@@ -18,6 +18,8 @@ describe IEX::Resources::Quote do
       expect(subject.week_52_low).to eq 87.73
       expect(subject.change_percent).to eq(-0.00508)
       expect(subject.change_percent_s).to eq '-0.51%'
+      expect(subject.extended_change_percent).to eq(-0.00008)
+      expect(subject.extended_change_percent_s).to eq '0.00%'
     end
     it 'coerces times' do
       expect(subject.latest_update).to eq 1_554_408_000_193


### PR DESCRIPTION
Added `extended_change_percent` and `extended_change_percent_s` to `quote.rb`.

One thing I'm unsure about is the rounding in `extended_change_percent_s`. Thoughts?