### PR TITLE
Add HTTP Referer configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 1.2.1 (Next)
 
+* [#82](https://github.com/dblock/iex-ruby-client/pull/82): Added `config.referer` to set HTTP `Referer` header. This enables IEX's "Manage domains" domain locking for tokens - [@agrberg](https://github.com/agrberg).
 * Your contribution here.
 
 ### 1.2.0 (2020/09/01)

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ timeout             | Optional open/read timeout in seconds.
 open_timeout        | Optional connection open timeout in seconds.
 publishable_token   | IEX Cloud API publishable token.
 endpoint            | Defaults to `https://cloud.iexapis.com/v1`.
+referer             | Optional string for HTTP `Referer` header, enables token domain management.
 
 ## Sandbox Environment
 

--- a/lib/iex/api/config.rb
+++ b/lib/iex/api/config.rb
@@ -14,6 +14,7 @@ module IEX
         endpoint
         publishable_token
         secret_token
+        referer
       ].freeze
 
       attr_accessor(*Config::ATTRIBUTES)
@@ -29,6 +30,7 @@ module IEX
         self.logger = nil
         self.timeout = nil
         self.open_timeout = nil
+        self.referer = nil
       end
     end
 

--- a/lib/iex/cloud/connection.rb
+++ b/lib/iex/cloud/connection.rb
@@ -15,6 +15,7 @@ module IEX
           options[:headers]['Accept'] = 'application/json; charset=utf-8'
           options[:headers]['Content-Type'] = 'application/json; charset=utf-8'
           options[:headers]['User-Agent'] = user_agent if user_agent
+          options[:headers]['Referer'] = referer if referer
           options[:proxy] = proxy if proxy
           options[:ssl] = { ca_path: ca_path, ca_file: ca_file } if ca_path || ca_file
 


### PR DESCRIPTION
Enables passing in a `referer` configuration option to set the HTTP `Referer` header. This is necessary to [lock tokens to a domain](https://iexcloud.io/docs/api/#authentication).

There weren't tests for each individual configuration variable, default, or headers (testing Faraday's API maybe?) so I wasn't sure what to add. I can confirm it works in actual usage in my app and that `bundle exec rake` runs clean after all changes too.