### PR TITLE
Enable Faraday logger configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [#82](https://github.com/dblock/iex-ruby-client/pull/82): Added `config.referer` to set HTTP `Referer` header. This enables IEX's "Manage domains" domain locking for tokens - [@agrberg](https://github.com/agrberg).
 * [#70](https://github.com/dblock/iex-ruby-client/pull/70): Added support for `ref_data_isin` taking a single `String` parameter - [@rodolfobandeira](https://github.com/rodolfobandeira).
 * [#84](https://github.com/dblock/iex-ruby-client/pull/84): Added support for Advanced Stats API - [@FanaHOVA](https://github.com/fanahova).
+* [#86](https://github.com/dblock/iex-ruby-client/issues/86): Added advanced logger configuration to `config.logger`. Now a hash with keys `:instance, :options, and :proc` can be passed and used directly with Faraday - [@agrberg](https://github.com/agrberg).
 * Your contribution here.
 
 ### 1.2.0 (2020/09/01)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A Ruby client for the [The IEX Cloud API](https://iexcloud.io/docs/api/).
   - [Get List](#get-list)
   - [Other Requests](#other-requests)
 - [Configuration](#configuration)
+  - [Logging](#logging)
 - [Sandbox Environment](#sandbox-environment)
 - [Errors](#errors)
   - [SymbolNotFound](#symbolnotfound)
@@ -465,12 +466,26 @@ user_agent          | User-agent, defaults to _IEX Ruby Client/version_.
 proxy               | Optional HTTP proxy.
 ca_path             | Optional SSL certificates path.
 ca_file             | Optional SSL certificates file.
-logger              | Optional `Logger` instance that logs HTTP requests.
+logger              | Optional `Logger` instance or hash to logs HTTP requests.
 timeout             | Optional open/read timeout in seconds.
 open_timeout        | Optional connection open timeout in seconds.
 publishable_token   | IEX Cloud API publishable token.
 endpoint            | Defaults to `https://cloud.iexapis.com/v1`.
 referer             | Optional string for HTTP `Referer` header, enables token domain management.
+
+### Logging
+
+Faraday will not log HTTP requests by default. In order to do this you can either provide a `logger` instance or configuration Hash to `IEX::Api::Client`. A configuration hash allows you to supply the `instance`, `options`, and configuration `proc` to [Faraday](https://lostisland.github.io/faraday/middleware/logger#include-and-exclude-headersbodies).
+
+```ruby
+IEX::Api::Client.configure do |config|
+  config.logger = {
+    instance: Logger.new(STDOUT),
+    options: { bodies: true },
+    proc: proc { |logger| logger.filter(/T?[sp]k_\w+/i, '[REMOVED]') }
+  }
+end
+```
 
 ## Sandbox Environment
 

--- a/lib/iex/cloud/connection.rb
+++ b/lib/iex/cloud/connection.rb
@@ -30,7 +30,13 @@ module IEX
             connection.use ::Faraday::Request::UrlEncoded
             connection.use ::IEX::Cloud::Response::RaiseError
             connection.use ::FaradayMiddleware::ParseJson, content_type: /\bjson$/
-            connection.response :logger, logger if logger
+            if logger
+              if logger.is_a?(Hash)
+                connection.response :logger, logger[:instance], logger[:options] || {}, &logger[:proc]
+              else
+                connection.response :logger, logger
+              end
+            end
             connection.adapter ::Faraday.default_adapter
           end
         end

--- a/spec/iex/client_spec.rb
+++ b/spec/iex/client_spec.rb
@@ -110,6 +110,23 @@ describe IEX::Api::Client do
         it 'creates a connection with a logger' do
           expect(client.send(:connection).builder.handlers).to include ::Faraday::Response::Logger
         end
+        context 'when configuring the logger' do
+          let(:logger) do
+            {
+              instance: Logger.new(STDOUT),
+              options: { foo: 'bar' },
+              proc: proc { |logger| logger.filter(/foo/, 'bar') }
+            }
+          end
+          it 'creates a connection with a configured logger' do
+            handler = client.send(:connection).builder.handlers.find { |h| h == ::Faraday::Response::Logger }
+            instance, options = handler.instance_variable_get(:@args)
+            proc = handler.instance_variable_get(:@block)
+            expect(instance).to eq(logger[:instance])
+            expect(options).to eq(logger[:options])
+            expect(proc).to eq(logger[:proc])
+          end
+        end
       end
     end
     context 'timeout options' do


### PR DESCRIPTION
Enable passing of logger configuration hash to Faraday for finer logger control.

[closes #86]