### PR TITLE
chore: update faraday to 2.7.10

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,5 +16,5 @@ jobs:
           bundler-cache: true
       - run: |
           # the personal token is public, this is ok, base64 encode to avoid tripping Github
-          TOKEN=$(echo -n NWY1ZmM5MzEyMzNlYWY4OTZiOGU3MmI3MWQ3Mzk0MzgxMWE4OGVmYwo= | base64 --decode)
+          TOKEN=$(echo -n Z2hwX0xNQ3VmanBFeTBvYkZVTWh6NVNqVFFBOEUxU25abzBqRUVuaAo= | base64 --decode)
           DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### 2.0.1 (Next)
+* [#120](https://github.com/dblock/iex-ruby-client/pull/120): Upgrade faraday to 2.7.10 - [@esarmstrong](https://github.com/esarmstrong).
 * Your contribution here.
 
 ### 2.0.0 (2022/07/24)

--- a/iex-ruby-client.gemspec
+++ b/iex-ruby-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'IEX Finance API Ruby client with support for retrieving stock quotes.'
   s.add_dependency 'faraday', '>= 0.17'
-  s.add_dependency 'faraday_middleware'
+  s.add_dependency 'faraday-multipart'
   s.add_dependency 'hashie'
   s.add_dependency 'money', '~> 6.0'
   s.add_development_dependency 'rake', '~> 10'

--- a/lib/iex-ruby-client.rb
+++ b/lib/iex-ruby-client.rb
@@ -1,6 +1,5 @@
 require 'faraday'
-require 'faraday_middleware'
-require 'faraday_middleware/response_middleware'
+require 'faraday/multipart'
 require 'hashie'
 require 'money'
 require 'date'

--- a/lib/iex/cloud/connection.rb
+++ b/lib/iex/cloud/connection.rb
@@ -9,11 +9,13 @@ module IEX
 
       def connection
         @connection ||= begin
-          options = {}
+          options = {
+            headers: {
+              'Accept' => 'application/json; charset=utf-8',
+              'Content-Type' => 'application/json; charset=utf-8'
+            }
+          }
 
-          options[:headers] = {}
-          options[:headers]['Accept'] = 'application/json; charset=utf-8'
-          options[:headers]['Content-Type'] = 'application/json; charset=utf-8'
           options[:headers]['User-Agent'] = user_agent if user_agent
           options[:headers]['Referer'] = referer if referer
           options[:proxy] = proxy if proxy
@@ -26,10 +28,10 @@ module IEX
           options[:request] = request_options if request_options.any?
 
           ::Faraday::Connection.new(endpoint, options) do |connection|
-            connection.use ::Faraday::Request::Multipart
-            connection.use ::Faraday::Request::UrlEncoded
+            connection.request :multipart
+            connection.request :url_encoded
             connection.use ::IEX::Cloud::Response::RaiseError
-            connection.use ::FaradayMiddleware::ParseJson, content_type: /\bjson$/
+            connection.response :json
             connection.response(:logger, logger.instance, logger.options, &logger.proc) if logger.instance
             connection.adapter ::Faraday.default_adapter
           end


### PR DESCRIPTION
[Faraday Middleware](https://github.com/lostisland/faraday_middleware) is deprecated with the release of Faraday 2.0. This PR removes the `faraday-middleware` gem, replacing needed middlewares with those bundled with Faraday 2.0 and [faraday-multipart](https://github.com/lostisland/faraday-multipart)